### PR TITLE
Update links to point to the latest documentation version

### DIFF
--- a/application-headers-and-footers.asciidoc
+++ b/application-headers-and-footers.asciidoc
@@ -6,7 +6,7 @@ layout: page
 
 = Application Headers & Footers
 
-As stated in the link:https://vaadin.com/docs/v13/business-app/overview.html[overview] the Business App Starter is structured as follows:
+As stated in the link:https://vaadin.com/docs/business-app/overview.html[overview] the Business App Starter is structured as follows:
 
 image::images/structure.png[align=center]
 

--- a/creating-new-views.asciidoc
+++ b/creating-new-views.asciidoc
@@ -53,7 +53,7 @@ public class MyView extends ViewFrame {
 }
 ----
 
-For more info see link:https://vaadin.com/docs/v13/business-app/simple-viewframe-example.html[Simple ViewFrame Example].
+For more info see link:https://vaadin.com/docs/business-app/simple-viewframe-example.html[Simple ViewFrame Example].
 
 == Please Remember
 A few things to keep in mind when creating a new view:
@@ -63,7 +63,7 @@ A few things to keep in mind when creating a new view:
 
 *The Business App Starter is built around `MainLayout.class`. Please use it as the default parent layout when creating new views.*
 
-For information regarding routing in Vaadin, please see link:https://vaadin.com/docs/v13/flow/routing/tutorial-routing-annotation.html[Routing and Navigation].
+For information regarding routing in Vaadin, please see link:https://vaadin.com/docs/flow/routing/tutorial-routing-annotation.html[Routing and Navigation].
 
 == Adding a View to the Sidebar
 Once you’ve created your view, it’s time to add it to the `NaviDrawer` so that it can be accessed via the UI. Open up `MainLayout.java`, and go to the `initNaviItems` method.

--- a/simple-viewframe-example.asciidoc
+++ b/simple-viewframe-example.asciidoc
@@ -102,4 +102,4 @@ UIUtils.setBackgroundColor(LumoStyles.Color.BASE_COLOR, header, footer);
 
 image::images/example-background.png[align=center]
 
-For more information on how to theme your application using the various Business App Starter utilities please see link:https://vaadin.com/docs/v13/business-app/theming.html[Theming].
+For more information on how to theme your application using the various Business App Starter utilities please see link:https://vaadin.com/docs/business-app/theming.html[Theming].


### PR DESCRIPTION
Remove `v13` part from links

Fixes https://github.com/vaadin/business-app-starter-flow-docs/issues/2